### PR TITLE
Fix namespaces uri

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -14,4 +14,10 @@ addUrl({url:"https://www.example.com",lastMod:"2007-08-01");
 new WebSitemapGenerator({});
 new SitemapIndexGenerator({});
 
-Remove deprecated Google Image sitemap tag : https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps?#deprecated
+Remove deprecated Google Image sitemap tag:
+    https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps?#deprecated
+    https://developers.google.com/search/blog/2022/05/spring-cleaning-sitemap-extensions
+
+Update Google Video Sitemap classes to match latest schema (missing attributes, mark deprecations):
+    https://developers.google.com/search/docs/crawling-indexing/sitemaps/video-sitemaps
+    https://developers.google.com/search/blog/2022/05/spring-cleaning-sitemap-extensions

--- a/TODO.txt
+++ b/TODO.txt
@@ -13,3 +13,5 @@ JS api
 addUrl({url:"https://www.example.com",lastMod:"2007-08-01");
 new WebSitemapGenerator({});
 new SitemapIndexGenerator({});
+
+Remove deprecated Google Image sitemap tag : https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps?#deprecated

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         
         <!-- Testing dependencies -->
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <xmlunit.version>2.9.1</xmlunit.version>
         
         <!-- Official Maven Plugins -->
         <maven-plugin-api.version>3.8.2</maven-plugin-api.version>
@@ -122,6 +123,26 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <version>${xmlunit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Not yet needed. Uncomment when starting to use more of XmlUnit
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-matchers</artifactId>
+            <version>${xmlunit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
+        -->
     </dependencies>
     
     <build>

--- a/src/main/java/com/redfin/sitemapgenerator/AbstractSitemapGeneratorOptions.java
+++ b/src/main/java/com/redfin/sitemapgenerator/AbstractSitemapGeneratorOptions.java
@@ -13,7 +13,7 @@ abstract class AbstractSitemapGeneratorOptions<T extends AbstractSitemapGenerato
 	boolean allowMultipleSitemaps = true;
 	String suffixStringPattern; // this will store some type of string pattern suitable per needs.
 	W3CDateFormat dateFormat;
-	int maxUrls = SitemapGenerator.MAX_URLS_PER_SITEMAP;
+	int maxUrls = SitemapConstants.MAX_URLS_PER_SITEMAP;
 	boolean autoValidate = false;
 	boolean gzip = false;
 	
@@ -62,12 +62,14 @@ abstract class AbstractSitemapGeneratorOptions<T extends AbstractSitemapGenerato
 	}
 	/**
 	 * The maximum number of URLs to allow per sitemap; the default is the
-	 * maximum allowed (50,000), but you can decrease it if you wish (to make
-	 * your auto-generated sitemaps smaller)
+	 * maximum allowed (see {@link SitemapConstants#MAX_URLS_PER_SITEMAP}), but you
+	 * can decrease it if you wish (to make your auto-generated sitemaps smaller)
 	 */
 	public T maxUrls(int maxUrls) {
-		if (maxUrls > SitemapGenerator.MAX_URLS_PER_SITEMAP) {
-			throw new SitemapException("You can only have 50,000 URLs per sitemap; to use more, allowMultipleSitemaps and generate a sitemap index. You asked for " + maxUrls);
+		if (maxUrls > SitemapConstants.MAX_URLS_PER_SITEMAP) {
+			throw new SitemapException(String.format(
+					"You can only have %d URLs per sitemap; to use more, allowMultipleSitemaps and generate a sitemap index. You asked for %d",
+					SitemapConstants.MAX_URLS_PER_SITEMAP, maxUrls));
 		}
 		this.maxUrls = maxUrls;
 		return getThis();

--- a/src/main/java/com/redfin/sitemapgenerator/GoogleImageSitemapGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/GoogleImageSitemapGenerator.java
@@ -77,27 +77,25 @@ public class GoogleImageSitemapGenerator extends SitemapGenerator<GoogleImageSit
 
     private static class Renderer extends AbstractSitemapUrlRenderer<GoogleImageSitemapUrl> implements ISitemapUrlRenderer<GoogleImageSitemapUrl> {
 
-        private static final String IMAGE_NS = "image";
-        
         public Class<GoogleImageSitemapUrl> getUrlClass() {
             return GoogleImageSitemapUrl.class;
         }
 
         public String getXmlNamespaces() {
-            return "xmlns:image=\"https://www.google.com/schemas/sitemap-image/1.1\"";
+            return String.format("xmlns:%s=\"%s\"", SitemapConstants.GOOGLE_IMAGE_NS, SitemapConstants.GOOGLE_IMAGE_NS_URI);
         }
 
         public void render(GoogleImageSitemapUrl url, StringBuilder sb, W3CDateFormat dateFormat) {
             StringBuilder tagSb = new StringBuilder();
 
             for(Image image : url.getImages()) {
-                tagSb.append("    <").append(IMAGE_NS).append(":image>\n");
-                renderTag(tagSb, IMAGE_NS, "loc", image.getUrl());
-                renderTag(tagSb, IMAGE_NS, "caption", image.getCaption());
-                renderTag(tagSb, IMAGE_NS, "title", image.getTitle());
-                renderTag(tagSb, IMAGE_NS, "geo_location", image.getGeoLocation());
-                renderTag(tagSb, IMAGE_NS, "license", image.getLicense());
-                tagSb.append("    </").append(IMAGE_NS).append(":image>\n");
+                tagSb.append("    <").append(SitemapConstants.GOOGLE_IMAGE_NS).append(":image>\n");
+                renderTag(tagSb, SitemapConstants.GOOGLE_IMAGE_NS, "loc", image.getUrl());
+                renderTag(tagSb, SitemapConstants.GOOGLE_IMAGE_NS, "caption", image.getCaption());
+                renderTag(tagSb, SitemapConstants.GOOGLE_IMAGE_NS, "title", image.getTitle());
+                renderTag(tagSb, SitemapConstants.GOOGLE_IMAGE_NS, "geo_location", image.getGeoLocation());
+                renderTag(tagSb, SitemapConstants.GOOGLE_IMAGE_NS, "license", image.getLicense());
+                tagSb.append("    </").append(SitemapConstants.GOOGLE_IMAGE_NS).append(":image>\n");
             }
             super.render(url, sb, dateFormat, tagSb.toString());
         }

--- a/src/main/java/com/redfin/sitemapgenerator/GoogleLinkSitemapGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/GoogleLinkSitemapGenerator.java
@@ -24,7 +24,7 @@ public class GoogleLinkSitemapGenerator extends SitemapGenerator<GoogleLinkSitem
 
 		public String getXmlNamespaces() {
 
-			return "xmlns:xhtml=\"https://www.w3.org/1999/xhtml\"";
+			return String.format("xmlns:xhtml=\"%s\"", SitemapConstants.GOOGLE_LINK_NS_URI);
 		}
 
 		public void render(final GoogleLinkSitemapUrl url, final StringBuilder sb, final W3CDateFormat dateFormat) {

--- a/src/main/java/com/redfin/sitemapgenerator/GoogleNewsSitemapGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/GoogleNewsSitemapGenerator.java
@@ -10,9 +10,6 @@ import java.net.URL;
  * @see <a href="https://developers.google.com/search/docs/crawling-indexing/sitemaps/news-sitemap">Google Developer: News Sitemap</a>
  */
 public class GoogleNewsSitemapGenerator extends SitemapGenerator<GoogleNewsSitemapUrl,GoogleNewsSitemapGenerator> {
-
-	/** 1000 URLs max in a Google News sitemap. */
-	public static final int MAX_URLS_PER_SITEMAP = 1000;
 	
 	/** Configures a builder so you can specify sitemap generator options
 	 * 
@@ -36,14 +33,15 @@ public class GoogleNewsSitemapGenerator extends SitemapGenerator<GoogleNewsSitem
 	public static SitemapGeneratorBuilder<GoogleNewsSitemapGenerator> builder(String baseUrl, File baseDir) throws MalformedURLException {
 		SitemapGeneratorBuilder<GoogleNewsSitemapGenerator> builder = 
 			new SitemapGeneratorBuilder<>(baseUrl, baseDir, GoogleNewsSitemapGenerator.class);
-		builder.maxUrls = GoogleNewsSitemapGenerator.MAX_URLS_PER_SITEMAP;
+		builder.maxUrls = SitemapConstants.GOOGLE_NEWS_MAX_URLS_PER_SITEMAP;
 		return builder;
 	}
 	
 	GoogleNewsSitemapGenerator(AbstractSitemapGeneratorOptions<?> options) {
 		super(options, new Renderer());
-		if (options.maxUrls > GoogleNewsSitemapGenerator.MAX_URLS_PER_SITEMAP) {
-			throw new SitemapException("Google News sitemaps can have only 1000 URLs per sitemap: " + options.maxUrls);
+		if (options.maxUrls > SitemapConstants.GOOGLE_NEWS_MAX_URLS_PER_SITEMAP) {
+			throw new SitemapException(String.format("Google News sitemaps can have only %d URLs per sitemap: %d",
+					SitemapConstants.GOOGLE_NEWS_MAX_URLS_PER_SITEMAP, options.maxUrls));
 		}
 	}
 
@@ -89,28 +87,26 @@ public class GoogleNewsSitemapGenerator extends SitemapGenerator<GoogleNewsSitem
 	
 	private static class Renderer extends AbstractSitemapUrlRenderer<GoogleNewsSitemapUrl> implements ISitemapUrlRenderer<GoogleNewsSitemapUrl> {
 
-		private static final String NEWS_NS = "news";
-		
 		public Class<GoogleNewsSitemapUrl> getUrlClass() {
 			return GoogleNewsSitemapUrl.class;
 		}
 
 		public String getXmlNamespaces() {
-			return "xmlns:news=\"https://www.google.com/schemas/sitemap-news/0.9\"";
+			return String.format("xmlns:%s=\"%s\"", SitemapConstants.GOOGLE_NEWS_NS, SitemapConstants.GOOGLE_NEWS_NS_URI);
 		}
 
 		public void render(GoogleNewsSitemapUrl url, StringBuilder sb, W3CDateFormat dateFormat) {
 			StringBuilder tagSb = new StringBuilder();
-			tagSb.append("    <").append(NEWS_NS).append(":news>\n");
-			tagSb.append("      <").append(NEWS_NS).append(":publication>\n");
-			renderSubTag(tagSb, NEWS_NS, "name", url.getPublication().getName());
-			renderSubTag(tagSb, NEWS_NS, "language", url.getPublication().getLanguage());
-			tagSb.append("      </").append(NEWS_NS).append(":publication>\n");
-			renderTag(tagSb, NEWS_NS, "genres", url.getGenres());
-			renderTag(tagSb, NEWS_NS, "publication_date", dateFormat.format(url.getPublicationDate()));
-			renderTag(tagSb, NEWS_NS, "title", url.getTitle());
-			renderTag(tagSb, NEWS_NS, "keywords", url.getKeywords());
-			tagSb.append("    </").append(NEWS_NS).append(":news>\n");
+			tagSb.append("    <").append(SitemapConstants.GOOGLE_NEWS_NS).append(":news>\n");
+			tagSb.append("      <").append(SitemapConstants.GOOGLE_NEWS_NS).append(":publication>\n");
+			renderSubTag(tagSb, SitemapConstants.GOOGLE_NEWS_NS, "name", url.getPublication().getName());
+			renderSubTag(tagSb, SitemapConstants.GOOGLE_NEWS_NS, "language", url.getPublication().getLanguage());
+			tagSb.append("      </").append(SitemapConstants.GOOGLE_NEWS_NS).append(":publication>\n");
+			renderTag(tagSb, SitemapConstants.GOOGLE_NEWS_NS, "genres", url.getGenres());
+			renderTag(tagSb, SitemapConstants.GOOGLE_NEWS_NS, "publication_date", dateFormat.format(url.getPublicationDate()));
+			renderTag(tagSb, SitemapConstants.GOOGLE_NEWS_NS, "title", url.getTitle());
+			renderTag(tagSb, SitemapConstants.GOOGLE_NEWS_NS, "keywords", url.getKeywords());
+			tagSb.append("    </").append(SitemapConstants.GOOGLE_NEWS_NS).append(":news>\n");
 			super.render(url, sb, dateFormat, tagSb.toString());
 		}
 		

--- a/src/main/java/com/redfin/sitemapgenerator/GoogleVideoSitemapGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/GoogleVideoSitemapGenerator.java
@@ -77,42 +77,41 @@ public class GoogleVideoSitemapGenerator extends SitemapGenerator<GoogleVideoSit
 
 	private static class Renderer extends AbstractSitemapUrlRenderer<GoogleVideoSitemapUrl> implements ISitemapUrlRenderer<GoogleVideoSitemapUrl> {
 
-		private static final String VIDEO_NS = "video";
-		
 		public Class<GoogleVideoSitemapUrl> getUrlClass() {
 			return GoogleVideoSitemapUrl.class;
 		}
 		
 		public String getXmlNamespaces() {
-			return "xmlns:video=\"https://www.google.com/schemas/sitemap-video/1.1\"";
+			return String.format("xmlns:%s=\"%s\"", SitemapConstants.GOOGLE_VIDEO_NS, SitemapConstants.GOOGLE_VIDEO_NS_URI);
 		}
 
 		public void render(GoogleVideoSitemapUrl url, StringBuilder sb, W3CDateFormat dateFormat) {
 			StringBuilder tagSb = new StringBuilder();
-			tagSb.append("    <").append(VIDEO_NS).append(":video>\n");
-			renderTag(tagSb, VIDEO_NS, "content_loc", url.getContentUrl());
+			tagSb.append("    <").append(SitemapConstants.GOOGLE_VIDEO_NS).append(":video>\n");
+			renderTag(tagSb, SitemapConstants.GOOGLE_VIDEO_NS, "content_loc", url.getContentUrl());
 			if (url.getPlayerUrl() != null) {
-				tagSb.append("      <").append(VIDEO_NS).append(":player_loc allow_embed=\"").append(url.getAllowEmbed()).append("\">");
+				tagSb.append("      <").append(SitemapConstants.GOOGLE_VIDEO_NS).append(":player_loc allow_embed=\"")
+						.append(url.getAllowEmbed()).append("\">");
 				tagSb.append(url.getPlayerUrl());
-				tagSb.append("</").append(VIDEO_NS).append(":player_loc>\n");
+				tagSb.append("</").append(SitemapConstants.GOOGLE_VIDEO_NS).append(":player_loc>\n");
 			}
-			renderTag(tagSb, VIDEO_NS, "thumbnail_loc", url.getThumbnailUrl());
-			renderTag(tagSb, VIDEO_NS, "title", url.getTitle());
-			renderTag(tagSb, VIDEO_NS, "description", url.getDescription());
-			renderTag(tagSb, VIDEO_NS, "rating", url.getRating());
-			renderTag(tagSb, VIDEO_NS, "view_count", url.getViewCount());
+			renderTag(tagSb, SitemapConstants.GOOGLE_VIDEO_NS, "thumbnail_loc", url.getThumbnailUrl());
+			renderTag(tagSb, SitemapConstants.GOOGLE_VIDEO_NS, "title", url.getTitle());
+			renderTag(tagSb, SitemapConstants.GOOGLE_VIDEO_NS, "description", url.getDescription());
+			renderTag(tagSb, SitemapConstants.GOOGLE_VIDEO_NS, "rating", url.getRating());
+			renderTag(tagSb, SitemapConstants.GOOGLE_VIDEO_NS, "view_count", url.getViewCount());
 			if (url.getPublicationDate() != null) {
-				renderTag(tagSb, VIDEO_NS, "publication_date", dateFormat.format(url.getPublicationDate()));
+				renderTag(tagSb, SitemapConstants.GOOGLE_VIDEO_NS, "publication_date", dateFormat.format(url.getPublicationDate()));
 			}
 			if (url.getTags() != null) {
 				for (String tag : url.getTags()) {
-					renderTag(tagSb, VIDEO_NS, "tag", tag);
+					renderTag(tagSb, SitemapConstants.GOOGLE_VIDEO_NS, "tag", tag);
 				}
 			}
-			renderTag(tagSb, VIDEO_NS, "category", url.getCategory());
-			renderTag(tagSb, VIDEO_NS, "family_friendly", url.getFamilyFriendly());
-			renderTag(tagSb, VIDEO_NS, "duration", url.getDurationInSeconds());
-			tagSb.append("    </").append(VIDEO_NS).append(":video>\n");
+			renderTag(tagSb, SitemapConstants.GOOGLE_VIDEO_NS, "category", url.getCategory());
+			renderTag(tagSb, SitemapConstants.GOOGLE_VIDEO_NS, "family_friendly", url.getFamilyFriendly());
+			renderTag(tagSb, SitemapConstants.GOOGLE_VIDEO_NS, "duration", url.getDurationInSeconds());
+			tagSb.append("    </").append(SitemapConstants.GOOGLE_VIDEO_NS).append(":video>\n");
 			super.render(url, sb, dateFormat, tagSb.toString());
 		}
 		

--- a/src/main/java/com/redfin/sitemapgenerator/Image.java
+++ b/src/main/java/com/redfin/sitemapgenerator/Image.java
@@ -42,20 +42,32 @@ public class Image {
     /** Retrieves URL of Image*/
     public URL getUrl() { return url; }
 
-    /** Retrieves title of image*/
+    /** Retrieves title of image
+     * @deprecated Since May 2022, see <a href="https://developers.google.com/search/blog/2022/05/spring-cleaning-sitemap-extensions">deprecation note</a>. Use IPTC metadata instead.
+     */
+    @Deprecated(since = "2022-05-06")
     public String getTitle() { return title; }
 
-    /** Retrieves captionof image*/
+    /** Retrieves caption of image
+     * @deprecated Since May 2022, see <a href="https://developers.google.com/search/blog/2022/05/spring-cleaning-sitemap-extensions">deprecation note</a>. Use IPTC metadata instead.
+     */
+    @Deprecated(since = "2022-05-06")
     public String getCaption() { return caption; }
 
-    /** Retrieves geolocation string of image*/
+    /** Retrieves geolocation string of image
+     * @deprecated Since May 2022, see <a href="https://developers.google.com/search/blog/2022/05/spring-cleaning-sitemap-extensions">deprecation note</a>. Use IPTC metadata instead.
+     */
+    @Deprecated(since = "2022-05-06")
     public String getGeoLocation() { return geoLocation; }
 
-    /** Retrieves license string of image*/
+    /** Retrieves license string of image
+     * @deprecated Since May 2022, see <a href="https://developers.google.com/search/blog/2022/05/spring-cleaning-sitemap-extensions">deprecation note</a>. Use IPTC metadata instead.
+     */
+    @Deprecated(since = "2022-05-06")
     public URL getLicense() { return license; }
 
     public static class ImageBuilder {
-        private URL url;
+        private final URL url;
         private String title;
         private String caption;
         private String geoLocation;
@@ -68,26 +80,46 @@ public class Image {
         public ImageBuilder(URL url) {
             this.url = url;
         }
-
+        
+        /**
+         * @deprecated Since May 2022, see <a href="https://developers.google.com/search/blog/2022/05/spring-cleaning-sitemap-extensions">deprecation note</a>. Use IPTC metadata instead.
+         */
+        @Deprecated(since = "2022-05-06")
         public ImageBuilder title(String title) {
             this.title = title;
             return this;
         }
-
+        
+        /**
+         * @deprecated Since May 2022, see <a href="https://developers.google.com/search/blog/2022/05/spring-cleaning-sitemap-extensions">deprecation note</a>. Use IPTC metadata instead.
+         */
+        @Deprecated(since = "2022-05-06")
         public ImageBuilder caption(String caption) {
             this.caption = caption;
             return this;
         }
-
+        
+        /**
+         * @deprecated Since May 2022, see <a href="https://developers.google.com/search/blog/2022/05/spring-cleaning-sitemap-extensions">deprecation note</a>. Use IPTC metadata instead.
+         */
+        @Deprecated(since = "2022-05-06")
         public ImageBuilder geoLocation(String geoLocation) {
             this.geoLocation = geoLocation;
             return this;
         }
-
+        
+        /**
+         * @deprecated Since May 2022, see <a href="https://developers.google.com/search/blog/2022/05/spring-cleaning-sitemap-extensions">deprecation note</a>. Use IPTC metadata instead.
+         */
+        @Deprecated(since = "2022-05-06")
         public ImageBuilder license(String license) throws MalformedURLException {
             return license(new URL(license));
         }
-
+        
+        /**
+         * @deprecated Since May 2022, see <a href="https://developers.google.com/search/blog/2022/05/spring-cleaning-sitemap-extensions">deprecation note</a>. Use IPTC metadata instead.
+         */
+        @Deprecated(since = "2022-05-06")
         public ImageBuilder license(URL license) {
             this.license = license;
             return this;

--- a/src/main/java/com/redfin/sitemapgenerator/SitemapConstants.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapConstants.java
@@ -1,0 +1,100 @@
+package com.redfin.sitemapgenerator;
+
+/**
+ * Utility class to contain basic values as constants.
+ **/
+public final class SitemapConstants {
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private SitemapConstants() {
+    }
+
+    /**
+     * Google Image sitemap namespace attribute.
+     *
+     * <p>See {@link GoogleImageSitemapGenerator} for more information.
+     */
+    public static final String GOOGLE_IMAGE_NS = "image";
+
+    /**
+     * Google Image sitemap namespace URI.
+     *
+     * <p>See {@link GoogleImageSitemapGenerator} for more information.
+     */
+    public static final String GOOGLE_IMAGE_NS_URI = "http://www.google.com/schemas/sitemap-image/1.1";
+
+    /**
+	 * @see <a href="https://developers.google.com/search/docs/specialty/international/localized-versions#sitemap">
+     *      Google Developers: Sitemap for alternate pages
+     */
+    public static final String GOOGLE_LINK_NS_URI = "http://www.w3.org/1999/xhtml";
+
+    /**
+     * 1000 URLs max in a Google News sitemap file.
+     *
+     * <p>See {@link GoogleNewsSitemapGenerator} for more information.
+     */
+    public static final int GOOGLE_NEWS_MAX_URLS_PER_SITEMAP = 1000;
+
+    /**
+     * Google News sitemap namespace attribute.
+     *
+     * <p>See {@link GoogleNewsSitemapGenerator} for more information.
+     */
+    public static final String GOOGLE_NEWS_NS = "news";
+
+    /**
+     * Google News sitemap namespace URI.
+     *
+     * <p>See {@link GoogleNewsSitemapGenerator} for more information.
+     */
+    public static final String GOOGLE_NEWS_NS_URI = "http://www.google.com/schemas/sitemap-news/0.9";
+
+    /**
+     * Google Video sitemap namespace attribute.
+     *
+     * <p>See {@link GoogleVideoSitemapGenerator} for more information.
+     */
+    public static final String GOOGLE_VIDEO_NS = "video";
+
+    /**
+     * Google Video sitemap namespace URI.
+     *
+     * <p>See {@link GoogleVideoSitemapGenerator} for more information.
+     */
+    public static final String GOOGLE_VIDEO_NS_URI = "http://www.google.com/schemas/sitemap-video/1.1";
+
+    /**
+     * Maximum 50000 URLs per sitemap file.
+     *
+     * @see <a href="https://www.sitemaps.org/protocol.html">
+     *      Sitemaps XML protocol</a>
+     */
+    public static final int MAX_URLS_PER_SITEMAP = 50000;
+
+    /** Maximum 50000 sitemaps per index allowed.
+     *
+     * @see <a href="https://www.sitemaps.org/protocol.html#index">
+     *      Sitemaps XML protocol</a>
+     */
+    public static final int MAX_SITEMAPS_PER_INDEX = 50000;
+
+    /**
+     * File name of sitemap index files, to group multiple sitemap files.
+     *
+     * @see <a href="https://www.sitemaps.org/protocol.html#index">
+     *      Sitemaps XML protocol</a>
+     */
+    public static final String SITEMAP_INDEX_FILE = "sitemap_index.xml";
+
+    /**
+     * Sitemap namespace URI to use with <code>sitemap.xml</code> file.
+     *
+     * @see <a href="https://www.sitemaps.org/protocol.html">
+     *      Sitemaps XML protocol</a>
+     */
+    public static final String SITEMAP_NS_URI = "http://www.sitemaps.org/schemas/sitemap/0.9";
+
+}

--- a/src/main/java/com/redfin/sitemapgenerator/SitemapGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapGenerator.java
@@ -13,9 +13,6 @@ import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
 abstract class SitemapGenerator<U extends ISitemapUrl, T extends SitemapGenerator<U,T>> {
-	/** 50000 URLs per sitemap maximum */
-	public static final int MAX_URLS_PER_SITEMAP = 50000;
-	
 	private final URL baseUrl;
 	private final File baseDir;
 	private final String fileNamePrefix;
@@ -193,7 +190,7 @@ abstract class SitemapGenerator<U extends ISitemapUrl, T extends SitemapGenerato
 	
 	private void writeSiteMapAsString(StringBuilder sb, List<U> urls) {
 		sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-		sb.append("<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" ");
+		sb.append(String.format("<urlset xmlns=\"%s\" ", SitemapConstants.SITEMAP_NS_URI));
 		if (renderer.getXmlNamespaces() != null) {
 			sb.append(renderer.getXmlNamespaces());
 			sb.append(' ');
@@ -210,7 +207,7 @@ abstract class SitemapGenerator<U extends ISitemapUrl, T extends SitemapGenerato
 	 * The sitemap index is written to {baseDir}/sitemap_index.xml
 	 */
 	public File writeSitemapsWithIndex() {
-		return writeSitemapsWithIndex(new File(baseDir, "sitemap_index.xml"));
+		return writeSitemapsWithIndex(new File(baseDir, SitemapConstants.SITEMAP_INDEX_FILE));
 	}
 
 	/**

--- a/src/main/java/com/redfin/sitemapgenerator/SitemapIndexGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapIndexGenerator.java
@@ -26,8 +26,6 @@ public class SitemapIndexGenerator {
 	private final W3CDateFormat dateFormat;
 	private final Date defaultLastMod;
 	private final boolean autoValidate;
-	/** Maximum 50,000 sitemaps per index allowed */
-	public static final int MAX_SITEMAPS_PER_INDEX = 50000;
 	
 	/** Options to configure sitemap index generation */
 	public static class Options {
@@ -35,7 +33,7 @@ public class SitemapIndexGenerator {
 		private final File outFile;
 		private W3CDateFormat dateFormat = null;
 		private boolean allowEmptyIndex = false;
-		private int maxUrls = MAX_SITEMAPS_PER_INDEX;
+		private int maxUrls = SitemapConstants.MAX_SITEMAPS_PER_INDEX;
 		private Date defaultLastMod = new Date();
 		private boolean autoValidate = false;
 		// TODO GZIP?  Is that legal for a sitemap index?
@@ -76,11 +74,12 @@ public class SitemapIndexGenerator {
 
 		/**
 		 * The maximum number of sitemaps to allow per sitemap index; the default is the
-		 * maximum allowed (1,000), but you can decrease it if you wish (for testing)
+		 * maximum allowed (see {@link SitemapConstants#MAX_SITEMAPS_PER_INDEX}), but
+		 * you can decrease it if you wish (for testing)
 		 */
 		Options maxUrls(int maxUrls) {
-			if (maxUrls > MAX_SITEMAPS_PER_INDEX) {
-				throw new SitemapException("You can't have more than 1000 sitemaps per index");
+			if (maxUrls > SitemapConstants.MAX_SITEMAPS_PER_INDEX) {
+				throw new SitemapException(String.format("You can't have more than %d sitemaps per index", SitemapConstants.MAX_SITEMAPS_PER_INDEX));
 			}
 			this.maxUrls = maxUrls;
 			return this;
@@ -253,7 +252,7 @@ public class SitemapIndexGenerator {
 
 	private void writeAsString(StringBuilder sb) {
 		sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"); 
-		sb.append("<sitemapindex xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\">\n");
+		sb.append(String.format("<sitemapindex xmlns=\"%s\">\n", SitemapConstants.SITEMAP_NS_URI));
 		for (SitemapIndexUrl url : urls) {
 			sb.append("  <sitemap>\n");
 			sb.append("    <loc>");

--- a/src/main/resources/com/redfin/sitemapgenerator/siteindex.xsd
+++ b/src/main/resources/com/redfin/sitemapgenerator/siteindex.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            targetNamespace="https://www.sitemaps.org/schemas/sitemap/0.9"
-            xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"
+            targetNamespace="http://www.sitemaps.org/schemas/sitemap/0.9"
+            xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
             elementFormDefault="qualified">
 <xsd:annotation>
   <xsd:documentation>
@@ -19,6 +19,7 @@
   </xsd:annotation>
   <xsd:complexType>
     <xsd:sequence>
+      <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
       <xsd:element name="sitemap" type="tSitemap" maxOccurs="unbounded"/>
     </xsd:sequence>
   </xsd:complexType>
@@ -30,10 +31,11 @@
       Container for the data needed to describe a sitemap.
     </xsd:documentation>
   </xsd:annotation>
-  <xsd:all>
+  <xsd:sequence>
     <xsd:element name="loc" type="tLocSitemap"/>
     <xsd:element name="lastmod" type="tLastmodSitemap" minOccurs="0"/>
-  </xsd:all>
+    <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+  </xsd:sequence>
 </xsd:complexType>
 
 <xsd:simpleType name="tLocSitemap">
@@ -65,9 +67,8 @@
     </xsd:simpleType>
     <xsd:simpleType>
       <xsd:restriction base="xsd:dateTime"/>
-      </xsd:simpleType>
+    </xsd:simpleType>
   </xsd:union>
 </xsd:simpleType>
-
 
 </xsd:schema>

--- a/src/main/resources/com/redfin/sitemapgenerator/sitemap.xsd
+++ b/src/main/resources/com/redfin/sitemapgenerator/sitemap.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            targetNamespace="https://www.sitemaps.org/schemas/sitemap/0.9"
-            xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"
+            targetNamespace="http://www.sitemaps.org/schemas/sitemap/0.9"
+            xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
             elementFormDefault="qualified">
 <xsd:annotation>
   <xsd:documentation>
@@ -19,6 +19,7 @@
   </xsd:annotation>
  <xsd:complexType>
    <xsd:sequence>
+     <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
      <xsd:element name="url" type="tUrl" maxOccurs="unbounded"/>
    </xsd:sequence>
  </xsd:complexType>

--- a/src/test/java/com/redfin/sitemapgenerator/GoogleImageSitemapUrlTest.java
+++ b/src/test/java/com/redfin/sitemapgenerator/GoogleImageSitemapUrlTest.java
@@ -55,7 +55,9 @@ class GoogleImageSitemapUrlTest {
         url.addImage(new Image("https://cdn.example.com/image2.jpg"));
         wsg.addUrl(url);
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:image=\"https://www.google.com/schemas/sitemap-image/1.1\" >\n" +
+                String.format("<urlset xmlns=\"%s\" xmlns:%s=\"%s\" >\n",
+                        SitemapConstants.SITEMAP_NS_URI, SitemapConstants.GOOGLE_IMAGE_NS,
+                        SitemapConstants.GOOGLE_IMAGE_NS_URI) +
                 "  <url>\n" +
                 "    <loc>https://www.example.com/index.html</loc>\n" +
                 "    <image:image>\n" +
@@ -81,7 +83,8 @@ class GoogleImageSitemapUrlTest {
         wsg.addUrl(url);
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:image=\"https://www.google.com/schemas/sitemap-image/1.1\" >\n" +
+                String.format("<urlset xmlns=\"%s\" xmlns:%s=\"%s\" >\n",
+                        SitemapConstants.SITEMAP_NS_URI, SitemapConstants.GOOGLE_IMAGE_NS, SitemapConstants.GOOGLE_IMAGE_NS_URI) +
                 "  <url>\n" +
                 "    <loc>https://www.example.com/index.html</loc>\n" +
                 "    <changefreq>weekly</changefreq>\n" +
@@ -121,7 +124,8 @@ class GoogleImageSitemapUrlTest {
         wsg.addUrl(url);
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:image=\"https://www.google.com/schemas/sitemap-image/1.1\" >\n" +
+                String.format("<urlset xmlns=\"%s\" xmlns:%s=\"%s\" >\n",
+                        SitemapConstants.SITEMAP_NS_URI, SitemapConstants.GOOGLE_IMAGE_NS, SitemapConstants.GOOGLE_IMAGE_NS_URI) +
                 "  <url>\n" +
                 "    <loc>https://www.example.com/index.html</loc>\n" +
                 "    <changefreq>weekly</changefreq>\n" +

--- a/src/test/java/com/redfin/sitemapgenerator/GoogleLinkSitemapUrlTest.java
+++ b/src/test/java/com/redfin/sitemapgenerator/GoogleLinkSitemapUrlTest.java
@@ -51,8 +51,8 @@ class GoogleLinkSitemapUrlTest {
 		final GoogleLinkSitemapUrl url = new GoogleLinkSitemapUrl("https://www.example.com/index.html", alternates);
 		wsg.addUrl(url);
 		final String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-			+ "<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" "
-			+ "xmlns:xhtml=\"https://www.w3.org/1999/xhtml\" >\n"
+			+ String.format("<urlset xmlns=\"%s\" xmlns:xhtml=\"%s\" >\n",
+					SitemapConstants.SITEMAP_NS_URI, SitemapConstants.GOOGLE_LINK_NS_URI)
 			+ "  <url>\n"
 			+ "    <loc>https://www.example.com/index.html</loc>\n"
 			+ "    <xhtml:link\n"
@@ -88,8 +88,8 @@ class GoogleLinkSitemapUrlTest {
 		final GoogleLinkSitemapUrl url = new GoogleLinkSitemapUrl("https://www.example.com/index.html", alternates);
 		wsg.addUrl(url);
 		final String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-			+ "<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" "
-			+ "xmlns:xhtml=\"https://www.w3.org/1999/xhtml\" >\n"
+			+ String.format("<urlset xmlns=\"%s\" xmlns:xhtml=\"%s\" >\n",
+					SitemapConstants.SITEMAP_NS_URI, SitemapConstants.GOOGLE_LINK_NS_URI)
 			+ "  <url>\n"
 			+ "    <loc>https://www.example.com/index.html</loc>\n"
 			+ "    <xhtml:link\n"

--- a/src/test/java/com/redfin/sitemapgenerator/GoogleNewsSitemapUrlTest.java
+++ b/src/test/java/com/redfin/sitemapgenerator/GoogleNewsSitemapUrlTest.java
@@ -44,7 +44,8 @@ class GoogleNewsSitemapUrlTest {
 		GoogleNewsSitemapUrl url = new GoogleNewsSitemapUrl("https://www.example.com/index.html", new Date(0), "Example Title", "The Example Times", "en");
 		wsg.addUrl(url);
 		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
-			"<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:news=\"https://www.google.com/schemas/sitemap-news/0.9\" >\n" +
+			String.format("<urlset xmlns=\"%s\" xmlns:%s=\"%s\" >\n",
+					SitemapConstants.SITEMAP_NS_URI, SitemapConstants.GOOGLE_NEWS_NS, SitemapConstants.GOOGLE_NEWS_NS_URI) +
 			"  <url>\n" + 
 			"    <loc>https://www.example.com/index.html</loc>\n" +
 			"    <news:news>\n" + 
@@ -72,7 +73,8 @@ class GoogleNewsSitemapUrlTest {
 			.build();
 		wsg.addUrl(url);
 		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
-			"<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:news=\"https://www.google.com/schemas/sitemap-news/0.9\" >\n" +
+			String.format("<urlset xmlns=\"%s\" xmlns:%s=\"%s\" >\n",
+					SitemapConstants.SITEMAP_NS_URI, SitemapConstants.GOOGLE_NEWS_NS, SitemapConstants.GOOGLE_NEWS_NS_URI) +
 			"  <url>\n" + 
 			"    <loc>https://www.example.com/index.html</loc>\n" +
 			"    <news:news>\n" + 
@@ -101,7 +103,8 @@ class GoogleNewsSitemapUrlTest {
 			.build();
 		wsg.addUrl(url);
 		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-			"<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:news=\"https://www.google.com/schemas/sitemap-news/0.9\" >\n" +
+			String.format("<urlset xmlns=\"%s\" xmlns:%s=\"%s\" >\n",
+					SitemapConstants.SITEMAP_NS_URI, SitemapConstants.GOOGLE_NEWS_NS, SitemapConstants.GOOGLE_NEWS_NS_URI) +
 			"  <url>\n" +
 			"    <loc>https://www.example.com/index.html</loc>\n" +
 			"    <news:news>\n" +

--- a/src/test/java/com/redfin/sitemapgenerator/GoogleVideoSitemapUrlTest.java
+++ b/src/test/java/com/redfin/sitemapgenerator/GoogleVideoSitemapUrlTest.java
@@ -53,7 +53,8 @@ class GoogleVideoSitemapUrlTest {
 		GoogleVideoSitemapUrl url = new GoogleVideoSitemapUrl(LANDING_URL, CONTENT_URL);
 		wsg.addUrl(url);
 		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
-			"<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:video=\"https://www.google.com/schemas/sitemap-video/1.1\" >\n" +
+			String.format("<urlset xmlns=\"%s\" xmlns:%s=\"%s\" >\n",
+					SitemapConstants.SITEMAP_NS_URI, SitemapConstants.GOOGLE_VIDEO_NS, SitemapConstants.GOOGLE_VIDEO_NS_URI) +
 			"  <url>\n" + 
 			"    <loc>https://www.example.com/index.html</loc>\n" +
 			"    <video:video>\n" + 
@@ -80,7 +81,8 @@ class GoogleVideoSitemapUrlTest {
 			.build();
 		wsg.addUrl(url);
 		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
-			"<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:video=\"https://www.google.com/schemas/sitemap-video/1.1\" >\n" +
+			String.format("<urlset xmlns=\"%s\" xmlns:%s=\"%s\" >\n",
+					SitemapConstants.SITEMAP_NS_URI, SitemapConstants.GOOGLE_VIDEO_NS, SitemapConstants.GOOGLE_VIDEO_NS_URI) +
 			"  <url>\n" + 
 			"    <loc>https://www.example.com/index.html</loc>\n" +
 			"    <video:video>\n" + 

--- a/src/test/java/com/redfin/sitemapgenerator/SitemapGeneratorTest.java
+++ b/src/test/java/com/redfin/sitemapgenerator/SitemapGeneratorTest.java
@@ -21,13 +21,13 @@ class SitemapGeneratorTest {
 	
 	
 	private static final String SITEMAP_PLUS_ONE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
-		"<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" >\n" + 
+		"<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" >\n" + 
 		"  <url>\n" + 
 		"    <loc>https://www.example.com/just-one-more</loc>\n" + 
 		"  </url>\n" + 
 		"</urlset>";
 	private static final String SITEMAP1 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
-		"<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" >\n" + 
+		"<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" >\n" + 
 		"  <url>\n" + 
 		"    <loc>https://www.example.com/0</loc>\n" + 
 		"  </url>\n" + 
@@ -60,7 +60,7 @@ class SitemapGeneratorTest {
 		"  </url>\n" + 
 		"</urlset>";
 	private static final String SITEMAP2 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
-		"<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" >\n" + 
+		"<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" >\n" + 
 		"  <url>\n" + 
 		"    <loc>https://www.example.com/10</loc>\n" + 
 		"  </url>\n" + 
@@ -119,7 +119,7 @@ class SitemapGeneratorTest {
 		wsg = new WebSitemapGenerator("https://www.example.com", dir);
 		wsg.addUrl("https://www.example.com/index.html");
 		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
-			"<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" >\n" + 
+			"<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" >\n" + 
 			"  <url>\n" + 
 			"    <loc>https://www.example.com/index.html</loc>\n" + 
 			"  </url>\n" + 
@@ -133,7 +133,7 @@ class SitemapGeneratorTest {
 		wsg = new WebSitemapGenerator("https://www.example.com", dir);
 		wsg.addUrls("https://www.example.com/index.html", "https://www.example.com/index2.html");
 		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
-			"<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" >\n" + 
+			"<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" >\n" + 
 			"  <url>\n" + 
 			"    <loc>https://www.example.com/index.html</loc>\n" + 
 			"  </url>\n" + 
@@ -154,7 +154,7 @@ class SitemapGeneratorTest {
 			.changeFreq(ChangeFreq.DAILY).lastMod(new Date(0)).priority(1.0).build();
 		wsg.addUrl(url);
 		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
-			"<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" >\n" + 
+			String.format("<urlset xmlns=\"%s\" >\n", SitemapConstants.SITEMAP_NS_URI) +
 			"  <url>\n" + 
 			"    <loc>https://www.example.com/index.html</loc>\n" + 
 			"    <lastmod>1970-01-01</lastmod>\n" + 
@@ -179,7 +179,7 @@ class SitemapGeneratorTest {
 		wsg.addUrl("https://www.example.com/index.html");
 		
 		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
-				"<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" >\n" + 
+				String.format("<urlset xmlns=\"%s\" >\n", SitemapConstants.SITEMAP_NS_URI) +
 				"  <url>\n" + 
 				"    <loc>https://www.example.com/index.html</loc>\n" + 
 				"  </url>\n" + 
@@ -221,7 +221,7 @@ class SitemapGeneratorTest {
 	@Test
 	void testTooManyUrls() throws Exception {
 		wsg = WebSitemapGenerator.builder("https://www.example.com", dir).allowMultipleSitemaps(false).build();
-		for (int i = 0; i < SitemapGenerator.MAX_URLS_PER_SITEMAP; i++) {
+		for (int i = 0; i < SitemapConstants.MAX_URLS_PER_SITEMAP; i++) {
 			wsg.addUrl("https://www.example.com/"+i);
 		}
 		assertThrows(RuntimeException.class, () -> wsg.addUrl("https://www.example.com/just-one-more"), "too many URLs allowed");
@@ -366,7 +366,7 @@ class SitemapGeneratorTest {
 	void testWriteEmptySitemap() throws Exception {
 		wsg = WebSitemapGenerator.builder("https://www.example.com", dir).allowEmptySitemap(true).build();
 		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-				"<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\" >\n" +
+				String.format("<urlset xmlns=\"%s\" >\n", SitemapConstants.SITEMAP_NS_URI) +
 				"</urlset>";
 		String sitemap = writeSingleSiteMap(wsg);
 		assertEquals(expected, sitemap);

--- a/src/test/java/com/redfin/sitemapgenerator/SitemapGeneratorTest.java
+++ b/src/test/java/com/redfin/sitemapgenerator/SitemapGeneratorTest.java
@@ -3,8 +3,6 @@ package com.redfin.sitemapgenerator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.xmlunit.builder.Input;
-import org.xmlunit.validation.ValidationResult;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -16,6 +14,7 @@ import java.util.List;
 import java.util.zip.GZIPInputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -369,8 +368,8 @@ class SitemapGeneratorTest {
 		} catch (Exception ex) {
 			e = ex;
 		}
-		assertTrue(e instanceof NullPointerException);
-		assertEquals(e.getMessage(), "To write to files, baseDir must not be null", "Correct exception was not thrown");
+        assertInstanceOf(NullPointerException.class, e);
+		assertEquals("To write to files, baseDir must not be null", e.getMessage(), "Correct exception was not thrown");
 	}
 	
 	@Test
@@ -408,7 +407,7 @@ class SitemapGeneratorTest {
 	
 	private String writeSingleSiteMap(WebSitemapGenerator wsg) {
 		List<File> files = wsg.write();
-		assertEquals(1, files.size(), "Too many files: " + files.toString());
+		assertEquals(1, files.size(), "Too many files: " + files);
 		assertEquals("sitemap.xml", files.get(0).getName(), "Sitemap misnamed");
 		return TestUtil.slurpFileAndDelete(files.get(0));
 	}

--- a/src/test/java/com/redfin/sitemapgenerator/SitemapGeneratorTest.java
+++ b/src/test/java/com/redfin/sitemapgenerator/SitemapGeneratorTest.java
@@ -3,6 +3,8 @@ package com.redfin.sitemapgenerator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.xmlunit.builder.Input;
+import org.xmlunit.validation.ValidationResult;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -18,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SitemapGeneratorTest {
-	
 	
 	private static final String SITEMAP_PLUS_ONE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
 		"<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" >\n" + 
@@ -126,6 +127,8 @@ class SitemapGeneratorTest {
 			"</urlset>";
 		String sitemap = writeSingleSiteMap(wsg);
 		assertEquals(expected, sitemap);
+		
+		TestUtil.isValidSitemap(sitemap);
 	}
 	
 	@Test
@@ -143,6 +146,8 @@ class SitemapGeneratorTest {
 			"</urlset>";
 		String sitemap = writeSingleSiteMap(wsg);
 		assertEquals(expected, sitemap);
+		
+		TestUtil.isValidSitemap(sitemap);
 	}
 	
 	@Test
@@ -164,6 +169,8 @@ class SitemapGeneratorTest {
 			"</urlset>";
 		String sitemap = writeSingleSiteMap(wsg);
 		assertEquals(expected, sitemap);
+		
+		TestUtil.isValidSitemap(sitemap);
 	}
 	
 	@Test
@@ -185,7 +192,9 @@ class SitemapGeneratorTest {
 				"  </url>\n" + 
 				"</urlset>";
 		String sitemap = writeSingleSiteMap(wsg);
-		assertEquals(expected, sitemap);		
+		assertEquals(expected, sitemap);
+		
+		TestUtil.isValidSitemap(sitemap);
 	}
 	
 	@Test
@@ -243,6 +252,8 @@ class SitemapGeneratorTest {
 		assertEquals("sitemap2.xml", files.get(1).getName(), "Second sitemap was misnamed");
 		actual = TestUtil.slurpFileAndDelete(files.get(1));
 		assertEquals(SITEMAP_PLUS_ONE, actual, "sitemap2 didn't match");
+		
+		TestUtil.isValidSitemap(actual);
 	}
 	
 	@Test
@@ -254,6 +265,8 @@ class SitemapGeneratorTest {
 		wsg.addUrl("https://www.example.com/9");
 		String actual = writeSingleSiteMap(wsg);
 		assertEquals(SITEMAP1, actual, "sitemap didn't match");
+		
+		TestUtil.isValidSitemap(actual);
 	}
 	
 	@Test
@@ -272,8 +285,12 @@ class SitemapGeneratorTest {
 		String actual = TestUtil.slurpFileAndDelete(files.get(0));
 		assertEquals(SITEMAP1, actual, "sitemap1 didn't match");
 		
+		TestUtil.isValidSitemap(actual);
+		
 		actual = TestUtil.slurpFileAndDelete(files.get(1));
 		assertEquals(SITEMAP2, actual, "sitemap2 didn't match");
+		
+		TestUtil.isValidSitemap(actual);
 	}
 	
 	@Test
@@ -295,13 +312,19 @@ class SitemapGeneratorTest {
 		String actual = TestUtil.slurpFileAndDelete(files.get(0));
 		assertEquals(expected, actual, "sitemap1 didn't match");
 		
+		TestUtil.isValidSitemap(actual);
+		
 		expected = SITEMAP2;
 		actual = TestUtil.slurpFileAndDelete(files.get(1));
 		assertEquals(expected, actual, "sitemap2 didn't match");
 		
+		TestUtil.isValidSitemap(actual);
+		
 		expected = SITEMAP_PLUS_ONE;
 		actual = TestUtil.slurpFileAndDelete(files.get(2));
 		assertEquals(expected, actual, "sitemap3 didn't match");
+		
+		TestUtil.isValidSitemap(actual);
 	}
 	
 	@Test
@@ -333,6 +356,7 @@ class SitemapGeneratorTest {
 		file.delete();
 		String actual = sb.toString();
 		assertEquals(SITEMAP1, actual, "sitemap didn't match");
+		TestUtil.isValidSitemap(actual);
 	}
 	
 	@Test

--- a/src/test/java/com/redfin/sitemapgenerator/SitemapIndexGeneratorTest.java
+++ b/src/test/java/com/redfin/sitemapgenerator/SitemapIndexGeneratorTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class SitemapIndexGeneratorTest {
 
 	private static final String INDEX = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
-			"<sitemapindex xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\">\n" + 
+			String.format("<sitemapindex xmlns=\"%s\">\n", SitemapConstants.SITEMAP_NS_URI) +
 			"  <sitemap>\n" + 
 			"    <loc>https://www.example.com/sitemap1.xml</loc>\n" + 
 			"    <lastmod>1970-01-01</lastmod>\n" + 
@@ -96,7 +96,7 @@ public class SitemapIndexGeneratorTest {
 		sig = new SitemapIndexGenerator.Options(EXAMPLE, outFile).allowEmptyIndex(true).build();
 		sig.write();
 		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-				"<sitemapindex xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\">\n" +
+				String.format("<sitemapindex xmlns=\"%s\">\n", SitemapConstants.SITEMAP_NS_URI) +
 				"</sitemapindex>";
 		String actual = TestUtil.slurpFileAndDelete(outFile);
 		assertEquals(expected, actual);
@@ -125,7 +125,7 @@ public class SitemapIndexGeneratorTest {
 		sig.write();
 		String actual = TestUtil.slurpFileAndDelete(outFile);
 		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
-				"<sitemapindex xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\">\n" + 
+				String.format("<sitemapindex xmlns=\"%s\">\n", SitemapConstants.SITEMAP_NS_URI) +
 				"  <sitemap>\n" + 
 				"    <loc>https://www.example.com/index.html</loc>\n" + 
 				"    <lastmod>1970-01-01</lastmod>\n" + 

--- a/src/test/java/com/redfin/sitemapgenerator/TestUtil.java
+++ b/src/test/java/com/redfin/sitemapgenerator/TestUtil.java
@@ -1,10 +1,18 @@
 package com.redfin.sitemapgenerator;
 
+import org.xmlunit.builder.Input;
+import org.xmlunit.validation.Languages;
+import org.xmlunit.validation.ValidationResult;
+import org.xmlunit.validation.Validator;
+
+import javax.xml.transform.Source;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestUtil {
 	public static String getResourceAsString(Class<?> clazz, String path) {
@@ -38,5 +46,17 @@ public class TestUtil {
 		}
 		file.delete();
 		return sb.toString();
+	}
+	
+	// This is a hack. Without this instantiation, we would not be able to access the XSD from the main classpath.
+	private static final TestUtil instance = new TestUtil();
+	
+	public static void isValidSitemap(String xml) {
+		Validator validator = Validator.forLanguage(Languages.W3C_XML_SCHEMA_NS_URI);
+		Source source = Input.fromStream(instance.getClass().getResourceAsStream("sitemap.xsd")).build();
+		
+		validator.setSchemaSource(source);
+		ValidationResult vr = validator.validateInstance(Input.fromString(xml).build());
+		assertTrue(vr.isValid(), vr.getProblems().toString());
 	}
 }


### PR DESCRIPTION
This PR attempts to close #18 

Namespace URI come back to "http", and centralized into one "constant" class.

I also import XSD file from https://www.sitemap.org into 0.9 version to update them.

Finally, I add one TODO to remove deprecated Google Image sitemap tag.

Just for information, with this code I can run unit tests from IQSS/Dataverse#10321